### PR TITLE
Fixed Namespaced call of Admintable

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -38,7 +38,7 @@
 {% endset %}
 
 {% set js %}
-    new Craft.ui.AdminTable({
+    new Craft.AdminTable({
         tableSelector: '#ingredients',
         noObjectsSelector: '#noingredients',
         deleteAction: 'cocktailrecipes/ingredients/deleteIngredient'


### PR DESCRIPTION
craft has removed the need for .ui. namespace for AdminTable js.
