### PR TITLE
Updated deprecated functions

### DIFF
--- a/CocktailRecipesPlugin.php
+++ b/CocktailRecipesPlugin.php
@@ -32,7 +32,7 @@ class CocktailRecipesPlugin extends BasePlugin
     /**
      * Register control panel routes
      */
-    public function hookRegisterCpRoutes()
+    public function registerCpRoutes()
     {
         return array(
             'cocktailrecipes\/ingredients\/new' => 'cocktailrecipes/ingredients/_edit',
@@ -43,7 +43,7 @@ class CocktailRecipesPlugin extends BasePlugin
     /**
      * Register twig extension
      */
-    public function hookAddTwigExtension()
+    public function addTwigExtension()
     {
         Craft::import('plugins.cocktailrecipes.twigextensions.CocktailRecipesTwigExtension');
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,7 +41,7 @@
     new Craft.AdminTable({
         tableSelector: '#ingredients',
         noObjectsSelector: '#noingredients',
-        deleteAction: 'cocktailrecipes/ingredients/deleteIngredient'
+        deleteAction: 'cocktailRecipes/ingredients/deleteIngredient'
     });
 {% endset %}
 {% includeJs js %}

--- a/templates/ingredients/_edit.html
+++ b/templates/ingredients/_edit.html
@@ -21,7 +21,7 @@
 {% set content %}
 
     <form method="post" action="" accept-charset="UTF-8">
-        <input type="hidden" name="action" value="cocktailrecipes/ingredients/saveIngredient" />
+        <input type="hidden" name="action" value="cocktailRecipes/ingredients/saveIngredient" />
         <input type="hidden" name="redirect" value="cocktailrecipes/ingredients/{ingredientId}" />
         <input type="hidden" name="ingredientId" value="{{ ingredientId }}" />
 


### PR DESCRIPTION
The functions to register control panel routes and to register twig extension were deprecated; updated per the documentation. Also located some typos causing 404 errors in templates directory.
